### PR TITLE
Use lightweight dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiortc==1.2.0
-requests==2.25.1
+aiortc==1.3.2
+requests==2.28.2
 cryptography<39

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiortc==1.3.2
+aiortc-datachannel-only==1.3.2.post3
 requests==2.28.2
 cryptography<39


### PR DESCRIPTION
Make installation faster. 
Use lightweight version of aiortc without all `PyAV`, `cffi` and `netifaces` dependencies.
Now it works even on Windows without need of building wheels for `netifaces`.